### PR TITLE
Unescape tweet contents when reposting the tweet

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function getOne(array) {
 }
 
 function post(tweet) {
-  return Twitter.post('statuses/update', { status: tweet.text }).then(_ => tweet);
+  return Twitter.post('statuses/update', { status: unescape(tweet.text) }).then(_ => tweet);
 }
 
 function addToDB(tweet) {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
   },
   "dependencies": {
     "dotenv": "6.1.0",
-    "twit": "2.2.11"
+    "twit": "2.2.11",
+    "unescape": "^1.0.1"
   },
   "devDependencies": {
-    "lambda-local": "^1.4.2",
-    "aws-sdk": "^2.50.0"
+    "aws-sdk": "^2.50.0",
+    "lambda-local": "^1.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,11 +144,23 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
+dotenv@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.1.0.tgz#9853b6ca98292acb7dec67a95018fa40bccff42c"
+  integrity sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
 
 extend@~3.0.0:
   version "3.0.1"
@@ -223,6 +235,11 @@ http-signature@~1.1.0:
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+
+is-extendable@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -410,9 +427,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-twit@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/twit/-/twit-2.2.5.tgz#241480bab71731162d2a87b27450e4aa3bb5be5f"
+twit@2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/twit/-/twit-2.2.11.tgz#554343d1cf343ddf503280db821f61be5ab407c3"
+  integrity sha512-BkdwvZGRVoUTcEBp0zuocuqfih4LB+kEFUWkWJOVBg6pAE9Ebv9vmsYTTrfXleZGf45Bj5H3A1/O9YhF2uSYNg==
   dependencies:
     bluebird "^3.1.5"
     mime "^1.3.4"
@@ -425,6 +443,13 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+unescape@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unescape/-/unescape-1.0.1.tgz#956e430f61cad8a4d57d82c518f5e6cc5d0dda96"
+  integrity sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==
+  dependencies:
+    extend-shallow "^2.0.1"
 
 url@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
Twitter API returns the tweet text with HTML escaping. This results in malformed tweets when posting the contents without any further processing.

This PR unescapes the tweet contents before posting. It does not alter the handling of tweets otherwise, i.e. they are still stored with the escaping in database.

NPM module `unescape` is added as a new dependency.